### PR TITLE
Allow partner staff to enroll in courses without first joining a required cohort

### DIFF
--- a/mogc_partnerships/pipeline.py
+++ b/mogc_partnerships/pipeline.py
@@ -18,7 +18,7 @@ class MembershipRequiredEnrollment(PipelineStep):
             cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
                 "cohort_id", flat=True
             )
-            if user.memberships.filter(cohort__in=cohort_ids).exists():
+            if user.memberships.filter(cohort__in=cohort_ids).exists() or user.is_staff:
                 return {}
             raise CourseEnrollmentStarted.PreventEnrollment(
                 "This course requires a partner membership."

--- a/mogc_partnerships/pipeline.py
+++ b/mogc_partnerships/pipeline.py
@@ -8,17 +8,26 @@ from openedx_filters.learning.filters import CourseEnrollmentStarted
 from .models import CohortOffering, Partner, PartnerOffering
 
 
+def user_can_access_course(user, course_key):
+    partner = Partner.objects.get(org=course_key.org)
+    offering = partner.offerings.get(course_key=course_key)
+    cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
+        "cohort_id", flat=True
+    )
+    user_in_cohort = user.memberships.filter(cohort__in=cohort_ids).exists()
+    user_is_partner_manager = user.management_memberships.filter(
+        user_id=user.id, partner_id=partner.id
+    ).exists()
+    if user_in_cohort or user_is_partner_manager:
+        return True
+
+
 class MembershipRequiredEnrollment(PipelineStep):
     """Prevents non-members from enrolling in partner courses."""
 
     def run_filter(self, user, course_key, mode):
         try:
-            partner = Partner.objects.get(org=course_key.org)
-            offering = partner.offerings.get(course_key=course_key)
-            cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
-                "cohort_id", flat=True
-            )
-            if user.memberships.filter(cohort__in=cohort_ids).exists() or user.is_staff:
+            if user_can_access_course(user, course_key):
                 return {}
             raise CourseEnrollmentStarted.PreventEnrollment(
                 "This course requires a partner membership."
@@ -46,12 +55,7 @@ class HidePartnerCourseAboutPages(PipelineStep):
             "course-v1:" + "+".join([org, course_id, run])
         )  # TODO: Find a better way to do this.
         try:
-            partner = Partner.objects.get(org=org)
-            offering = partner.offerings.get(course_key=course_key)
-            cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
-                "id", flat=True
-            )
-            if user.memberships.filter(cohort__in=cohort_ids).exists():
+            if user_can_access_course(user, course_key):
                 return {}
             raise Http404
         except PartnerOffering.DoesNotExist:

--- a/mogc_partnerships/pipeline.py
+++ b/mogc_partnerships/pipeline.py
@@ -14,12 +14,11 @@ def user_can_access_course(user, course_key):
     cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
         "cohort_id", flat=True
     )
-    user_in_cohort = user.memberships.filter(cohort__in=cohort_ids).exists()
-    user_is_partner_manager = user.management_memberships.filter(
+    cohort_membership = user.memberships.filter(cohort__in=cohort_ids)
+    management_membership = user.management_memberships.filter(
         user_id=user.id, partner_id=partner.id
-    ).exists()
-    if user_in_cohort or user_is_partner_manager:
-        return True
+    )
+    return cohort_membership.exists() or management_membership.exists()
 
 
 class MembershipRequiredEnrollment(PipelineStep):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,6 +14,7 @@ from openedx_filters.learning.filters import (
 from mogc_partnerships.factories import (
     CohortMembershipFactory,
     CohortOfferingFactory,
+    PartnerManagementMembershipFactory,
     UserFactory,
 )
 
@@ -74,9 +75,10 @@ class TestMembershipRequiredEnrollment(TestCase):
         user = UserFactory(is_staff=True)
         course_key = CourseKey.from_string("course-v1:GizmonicInstitute+MST3K+S1_E1")
         mode = "honor"
-        CohortOfferingFactory(
+        offering = CohortOfferingFactory(
             cohort__partner__org=course_key.org, offering__course_key=course_key
         )
+        PartnerManagementMembershipFactory(partner=offering.cohort.partner, user=user)
         result = CourseEnrollmentStarted.run_filter(user, course_key, mode)
         self.assertEqual(result, (user, course_key, mode))
 
@@ -135,6 +137,20 @@ class TestHidePartnerCourseAboutPages(TestCase):
             cohort__partner__org=course_key.org, offering__course_key=course_key
         )
         CohortMembershipFactory(cohort=offering.cohort, email=user.email, user=user)
+        course_details = CourseDetails.from_course_key(course_key)
+        context = {"course_details": course_details}
+        template_name = "page_template.html"
+        with impersonate(user):
+            result = CourseAboutRenderStarted.run_filter(context, template_name)
+        self.assertEqual(result, (context, template_name))
+
+    def test_displays_courses_to_partner_managers(self):
+        user = UserFactory()
+        course_key = CourseKey.from_string("course-v1:GizmonicInstitute+MST3K+S1_E1")
+        offering = CohortOfferingFactory(
+            cohort__partner__org=course_key.org, offering__course_key=course_key
+        )
+        PartnerManagementMembershipFactory(partner=offering.cohort.partner, user=user)
         course_details = CourseDetails.from_course_key(course_key)
         context = {"course_details": course_details}
         template_name = "page_template.html"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -70,6 +70,16 @@ class TestMembershipRequiredEnrollment(TestCase):
         result = CourseEnrollmentStarted.run_filter(user, course_key, mode)
         self.assertEqual(result, (user, course_key, mode))
 
+    def test_allows_partner_staff_enrollment_without_cohort_membership(self):
+        user = UserFactory(is_staff=True)
+        course_key = CourseKey.from_string("course-v1:GizmonicInstitute+MST3K+S1_E1")
+        mode = "honor"
+        CohortOfferingFactory(
+            cohort__partner__org=course_key.org, offering__course_key=course_key
+        )
+        result = CourseEnrollmentStarted.run_filter(user, course_key, mode)
+        self.assertEqual(result, (user, course_key, mode))
+
 
 @override_settings(
     OPEN_EDX_FILTERS_CONFIG={


### PR DESCRIPTION
### Fixes https://github.com/academic-innovation/frontend-app-mogc-partners/issues/46

Updates enrollment filter to allow staff users to enroll in a course without first becoming a member of a required cohort.