### PR TITLE
Update CohortMembership create view and serializer to accept list uploads

### DIFF
--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -117,8 +117,9 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         # bulk_create doesn't return autoincremented IDs with MySQL DBs
         # so we have to query results separately
         return models.CohortMembership.objects.filter(
-            email__in=[cm.email for cm in objects]
-        ).all()
+            email__in=[cm.email for cm in objects],
+            cohort=cohort
+        )
 
 
 class CohortMembershipSerializer(serializers.ModelSerializer):

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+
 from rest_framework import serializers
 
 from . import models

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 
 from . import models
 
@@ -100,7 +99,9 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         membership_accounts = User.objects.filter(
             email__in=[email for email in member_emails]
         ).values_list()
-        account_email_map = { user.email: user for user in membership_accounts }
+        account_email_map = {
+            user.email: user for user in membership_accounts
+        }
 
         cohort_memberships = [
             models.CohortMembership(
@@ -108,7 +109,9 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
             ) for member_email in member_emails
         ]
 
-        return models.CohortMembership.objects.bulk_create(cohort_memberships)
+        return models.CohortMembership.objects.bulk_create(
+            cohort_memberships, ignore_conflicts=True
+        )
 
 
 class CohortMembershipSerializer(serializers.ModelSerializer):

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -99,14 +99,15 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         membership_accounts = User.objects.filter(
             email__in=[email for email in member_emails]
         ).values_list()
-        account_email_map = {
-            user.email: user for user in membership_accounts
-        }
+        account_email_map = {user.email: user for user in membership_accounts}
 
         cohort_memberships = [
             models.CohortMembership(
-                user=account_email_map.get(member_email), cohort=cohort, email=member_email
-            ) for member_email in member_emails
+                user=account_email_map.get(member_email),
+                cohort=cohort,
+                email=member_email,
+            )
+            for member_email in member_emails
         ]
 
         return models.CohortMembership.objects.bulk_create(

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -1,4 +1,6 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from . import models
 
@@ -89,6 +91,26 @@ class CohortOfferingSerializer(serializers.ModelSerializer):
         return obj.offering_id in context["enrollments"]
 
 
+class CohortMembershipListSerializer(serializers.ListSerializer):
+    def create(self, validated_data):
+        cohort = self.context.get("cohort")
+        member_emails = [o["email"] for o in validated_data]
+
+        User = get_user_model()
+        membership_accounts = User.objects.filter(
+            email__in=[email for email in member_emails]
+        ).values_list()
+        account_email_map = { user.email: user for user in membership_accounts }
+
+        cohort_memberships = [
+            models.CohortMembership(
+                user=account_email_map.get(member_email), cohort=cohort, email=member_email
+            ) for member_email in member_emails
+        ]
+
+        return models.CohortMembership.objects.bulk_create(cohort_memberships)
+
+
 class CohortMembershipSerializer(serializers.ModelSerializer):
     """Serializer for CohortMembership objects."""
 
@@ -101,6 +123,18 @@ class CohortMembershipSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.CohortMembership
         fields = ["id", "cohort", "partner", "email", "user", "name"]
+        list_serializer_class = CohortMembershipListSerializer
+
+    def create(self, validated_data):
+        validated_data["cohort"] = self.context.get("cohort")
+
+        User = get_user_model()
+        try:
+            validated_data["user"] = User.objects.get(email=validated_data.get("email"))
+        except User.DoesNotExist:
+            validated_data["user"] = None
+
+        return models.CohortMembership.objects.create(**validated_data)
 
 
 class EnrollmentRecordSerializer(serializers.ModelSerializer):

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -117,8 +117,7 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         # bulk_create doesn't return autoincremented IDs with MySQL DBs
         # so we have to query results separately
         return models.CohortMembership.objects.filter(
-            email__in=[cm.email for cm in objects],
-            cohort=cohort
+            email__in=[cm.email for cm in objects], cohort=cohort
         )
 
 

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -111,9 +111,11 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
             for member_email in member_emails
         ]
 
-        return models.CohortMembership.objects.bulk_create(
+        objects = models.CohortMembership.objects.bulk_create(
             cohort_memberships, ignore_conflicts=True
         )
+        # bulk_create doesn't return autoincremented IDs with MySQL DBs, so we have to query results
+        return models.CohortMembership.objects.filter(email__in=[cm.email for cm in objects]).all()
 
 
 class CohortMembershipSerializer(serializers.ModelSerializer):

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -115,7 +115,9 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
             cohort_memberships, ignore_conflicts=True
         )
         # bulk_create doesn't return autoincremented IDs with MySQL DBs, so we have to query results
-        return models.CohortMembership.objects.filter(email__in=[cm.email for cm in objects]).all()
+        return models.CohortMembership.objects.filter(
+            email__in=[cm.email for cm in objects]
+        ).all()
 
 
 class CohortMembershipSerializer(serializers.ModelSerializer):

--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -114,7 +114,8 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         objects = models.CohortMembership.objects.bulk_create(
             cohort_memberships, ignore_conflicts=True
         )
-        # bulk_create doesn't return autoincremented IDs with MySQL DBs, so we have to query results
+        # bulk_create doesn't return autoincremented IDs with MySQL DBs
+        # so we have to query results separately
         return models.CohortMembership.objects.filter(
             email__in=[cm.email for cm in objects]
         ).all()

--- a/mogc_partnerships/urls.py
+++ b/mogc_partnerships/urls.py
@@ -57,15 +57,4 @@ urlpatterns = [
         views.EnrollmentRecordListView.as_view(),
         name="record_list",
     ),
-    # TODO: Remove the following routes after the MFE has been updated.
-    path(
-        f"{API_PREFIX}/catalogs/",
-        views.CohortListView.as_view(),
-        name="catalog_list",
-    ),
-    path(
-        f"{API_PREFIX}/catalogs/<uuid:uuid>",
-        views.CohortDetailView.as_view(),
-        name="catalog_detail",
-    ),
 ]

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth import get_user_model
 from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404, redirect
 

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -194,6 +194,7 @@ class CohortMembershipCreateView(generics.CreateAPIView):
     def perform_create(self, serializer):
         serializer.save()
 
+
 class EnrollmentRecordListView(generics.ListAPIView):
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -189,10 +189,7 @@ class CohortMembershipCreateView(generics.CreateAPIView):
         except PartnerCohort.DoesNotExist:
             raise PermissionDenied("No")
 
-        return {"cohort": cohort, "user": user}
-
-    def perform_create(self, serializer):
-        serializer.save()
+        return {"cohort": cohort}
 
 
 class EnrollmentRecordListView(generics.ListAPIView):

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -172,25 +172,28 @@ class CohortMembershipCreateView(generics.CreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = serializers.CohortMembershipSerializer
 
-    def perform_create(self, serializer):
-        user = self.request.user
-        managed_partners = Partner.objects.active().for_user(user)
-        managed_cohorts = PartnerCohort.objects.filter(
-            partner__in=managed_partners.values_list("id", flat=True)
-        )
-        cohort_uuid = self.kwargs.get("cohort_uuid")
+    def get_serializer(self, *args, **kwargs):
+        if isinstance(kwargs.get("data", {}), list):
+            kwargs["many"] = True
+
+        return super(CohortMembershipCreateView, self).get_serializer(*args, **kwargs)
+
+    def get_serializer_context(self):
         try:
+            user = self.request.user
+            managed_partners = Partner.objects.active().for_user(user)
+            managed_cohorts = PartnerCohort.objects.filter(
+                partner__in=managed_partners.values_list("id", flat=True)
+            )
+            cohort_uuid = self.kwargs.get("cohort_uuid")
             cohort = managed_cohorts.get(uuid=cohort_uuid)
         except PartnerCohort.DoesNotExist:
             raise PermissionDenied("No")
-        email = serializer.validated_data.get("email")
-        User = get_user_model()
-        try:
-            membership_account = User.objects.get(email=email)
-        except User.DoesNotExist:
-            membership_account = None
-        serializer.save(cohort=cohort, user=membership_account)
 
+        return {"cohort": cohort, "user": user}
+
+    def perform_create(self, serializer):
+        serializer.save()
 
 class EnrollmentRecordListView(generics.ListAPIView):
     authentication_classes = [SessionAuthentication]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
-import pytest
 import json
+
+import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from mogc_partnerships import factories, views

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -500,6 +500,7 @@ class TestCohortMembershipCreateView:
         response = member_create_view(request, cohort_uuid=cohort.uuid)
 
         assert response.status_code == 201
+        assert len(response.data) == 100
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -492,7 +492,7 @@ class TestCohortMembershipCreateView:
         request = api_rf.post(
             f"/memberships/{cohort.uuid}/",
             json.dumps(user_data),
-            content_type="application/json"
+            content_type="application/json",
         )
         force_authenticate(request, manager.user)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -489,12 +489,17 @@ class TestCohortMembershipCreateView:
         member_create_view = views.CohortMembershipCreateView.as_view()
         user_data = [{"email": "test-{}@test.com".format(i)} for i in range(100)]
 
-        request = api_rf.post(f"/memberships/{cohort.uuid}/", json.dumps(user_data), content_type="application/json")
+        request = api_rf.post(
+            f"/memberships/{cohort.uuid}/",
+            json.dumps(user_data),
+            content_type="application/json"
+        )
         force_authenticate(request, manager.user)
 
         response = member_create_view(request, cohort_uuid=cohort.uuid)
 
         assert response.status_code == 201
+
 
 @pytest.mark.django_db
 class TestEnrollmentRecordListView:


### PR DESCRIPTION
### Fixes Part 1/2 of https://github.com/academic-innovation/frontend-app-mogc-partners/issues/53

- Update `CohortMembershipCreateView` to add cohort and user to context
- Add `CohortMembershipListSerializer` to handle bulk inserts
- Update `CohortMembershipSerializer` to use list serializer if `data` is a list
- Remove `catalog` endpoints now that they are fully replace in frontend app

For use in https://github.com/academic-innovation/frontend-app-mogc-partners/pull/74.