### PR TITLE
Fix bulk import for existing user accounts

### DIFF
--- a/mogc_partnerships/serializers.py
+++ b/mogc_partnerships/serializers.py
@@ -99,7 +99,7 @@ class CohortMembershipListSerializer(serializers.ListSerializer):
         User = get_user_model()
         membership_accounts = User.objects.filter(
             email__in=[email for email in member_emails]
-        ).values_list()
+        )
         account_email_map = {user.email: user for user in membership_accounts}
 
         cohort_memberships = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -502,6 +502,27 @@ class TestCohortMembershipCreateView:
         assert response.status_code == 201
         assert len(response.data) == 100
 
+    def test_bulk_create_with_existing_user(self, api_rf):
+        """Managers can upload a list of emails to bulk create memberships"""
+
+        manager = factories.PartnerManagementMembershipFactory()
+        factories.UserFactory(email="foo@bar.com")
+        cohort = factories.PartnerCohortFactory(partner=manager.partner)
+        member_create_view = views.CohortMembershipCreateView.as_view()
+        user_data = [{"email": "foo@bar.com"}]
+
+        request = api_rf.post(
+            f"/memberships/{cohort.uuid}/",
+            json.dumps(user_data),
+            content_type="application/json",
+        )
+        force_authenticate(request, manager.user)
+
+        response = member_create_view(request, cohort_uuid=cohort.uuid)
+
+        assert response.status_code == 201
+        assert len(response.data) == 1
+
 
 @pytest.mark.django_db
 class TestEnrollmentRecordListView:


### PR DESCRIPTION
Fixes https://trello.com/c/8yC61eoT/580-molp-partner-admin-i-am-unable-to-add-a-specific-learner-via-importstill-investigating

Bulk import was breaking on emails with existing user accounts:
```
2024-08-27 11:26:24 Traceback (most recent call last):
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
2024-08-27 11:26:24     response = get_response(request)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
2024-08-27 11:26:24     response = wrapped_callback(request, *callback_args, **callback_kwargs)
2024-08-27 11:26:24   File "/opt/pyenv/versions/3.8.15/lib/python3.8/contextlib.py", line 75, in inner
2024-08-27 11:26:24     return func(*args, **kwds)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
2024-08-27 11:26:24     return view_func(*args, **kwargs)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
2024-08-27 11:26:24     return self.dispatch(request, *args, **kwargs)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
2024-08-27 11:26:24     response = self.handle_exception(exc)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
2024-08-27 11:26:24     self.raise_uncaught_exception(exc)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
2024-08-27 11:26:24     raise exc
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
2024-08-27 11:26:24     response = handler(request, *args, **kwargs)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/generics.py", line 190, in post
2024-08-27 11:26:24     return self.create(request, *args, **kwargs)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
2024-08-27 11:26:24     self.perform_create(serializer)
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/mixins.py", line 24, in perform_create
2024-08-27 11:26:24     serializer.save()
2024-08-27 11:26:24   File "/openedx/venv/lib/python3.8/site-packages/rest_framework/serializers.py", line 708, in save
2024-08-27 11:26:24     self.instance = self.create(validated_data)
2024-08-27 11:26:24   File "/openedx/requirements/mogc-partnerships/mogc_partnerships/serializers.py", line 104, in create
2024-08-27 11:26:24     account_email_map = {user.email: user for user in membership_accounts}
2024-08-27 11:26:24   File "/openedx/requirements/mogc-partnerships/mogc_partnerships/serializers.py", line 104, in <dictcomp>
2024-08-27 11:26:24     account_email_map = {user.email: user for user in membership_accounts}
2024-08-27 11:26:24 AttributeError: 'tuple' object has no attribute 'email'
```
This was due to an improper usage of `values_list`.