### PR TITLE
Display non-partner courses for anon users

### DIFF
--- a/mogc_partnerships/pipeline.py
+++ b/mogc_partnerships/pipeline.py
@@ -14,9 +14,8 @@ def get_course_key(context):
     course_id = course_details.course_id
     run = course_details.run
     # TODO: Find a better way to do this.
-    return CourseKey.from_string(
-        "course-v1:" + "+".join([org, course_id, run])
-    )
+    return CourseKey.from_string("course-v1:" + "+".join([org, course_id, run]))
+
 
 def user_can_access_course(user, partner, offering):
     if not user or user.is_anonymous:

--- a/mogc_partnerships/pipeline.py
+++ b/mogc_partnerships/pipeline.py
@@ -8,9 +8,19 @@ from openedx_filters.learning.filters import CourseEnrollmentStarted
 from .models import CohortOffering, Partner, PartnerOffering
 
 
-def user_can_access_course(user, course_key):
-    partner = Partner.objects.get(org=course_key.org)
-    offering = partner.offerings.get(course_key=course_key)
+def get_course_key(context):
+    course_details = context["course_details"]
+    org = course_details.org
+    course_id = course_details.course_id
+    run = course_details.run
+    # TODO: Find a better way to do this.
+    return CourseKey.from_string(
+        "course-v1:" + "+".join([org, course_id, run])
+    )
+
+def user_can_access_course(user, partner, offering):
+    if not user or user.is_anonymous:
+        raise Http404
     cohort_ids = CohortOffering.objects.filter(offering=offering).values_list(
         "cohort_id", flat=True
     )
@@ -26,7 +36,9 @@ class MembershipRequiredEnrollment(PipelineStep):
 
     def run_filter(self, user, course_key, mode):
         try:
-            if user_can_access_course(user, course_key):
+            partner = Partner.objects.get(org=course_key.org)
+            offering = partner.offerings.get(course_key=course_key)
+            if user_can_access_course(user, partner, offering):
                 return {}
             raise CourseEnrollmentStarted.PreventEnrollment(
                 "This course requires a partner membership."
@@ -44,17 +56,11 @@ class HidePartnerCourseAboutPages(PipelineStep):
 
     def run_filter(self, context, template_name):
         user = get_current_user()
-        if not user or user.is_anonymous:
-            raise Http404
-        course_details = context["course_details"]
-        org = course_details.org
-        course_id = course_details.course_id
-        run = course_details.run
-        course_key = CourseKey.from_string(
-            "course-v1:" + "+".join([org, course_id, run])
-        )  # TODO: Find a better way to do this.
+        course_key = get_course_key(context)
         try:
-            if user_can_access_course(user, course_key):
+            partner = Partner.objects.get(org=course_key.org)
+            offering = partner.offerings.get(course_key=course_key)
+            if user_can_access_course(user, partner, offering):
                 return {}
             raise Http404
         except PartnerOffering.DoesNotExist:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -104,6 +104,16 @@ class TestHidePartnerCourseAboutPages(TestCase):
             result = CourseAboutRenderStarted.run_filter(context, template_name)
         self.assertEqual(result, (context, template_name))
 
+    def test_displays_regular_courses_anon_user(self):
+        user = AnonymousUser()
+        course_key = CourseKey.from_string("course-v1:GizmonicInstitute+MST3K+S1_E1")
+        course_details = CourseDetails.from_course_key(course_key)
+        context = {"course_details": course_details}
+        template_name = "page_template.html"
+        with impersonate(user):
+            result = CourseAboutRenderStarted.run_filter(context, template_name)
+        self.assertEqual(result, (context, template_name))
+
     def test_hides_partner_courses(self):
         user = UserFactory()
         course_key = CourseKey.from_string("course-v1:GizmonicInstitute+MST3K+S1_E1")


### PR DESCRIPTION
Fixes `HidePartnerCourseAboutPages` to not hide about pages for anon users unless they are partner offerings.

**Expected Behavior**
- ✅ Non-partner courses will display about pages for all users
- Partner courses will:
  -  ❌ Return 404 if `PartnerOffering` doesn't exist
  - ❌ Return 404 if no user or user is anonymous
  - ❌ Return 404 if user isn't cohort member or manager
  - ✅ Display about page if `PartnerOffering` & user is in cohort or is partner manager