### PR TITLE
Deactivation flow QA follow up

### DIFF
--- a/mogc_partnerships/apps.py
+++ b/mogc_partnerships/apps.py
@@ -52,6 +52,13 @@ class PartnershipsAppConfig(AppConfig):
                             "COURSE_ENROLLMENT_CREATED"
                         ),
                     },
+                    {
+                        PluginSignals.RECEIVER_FUNC_NAME: "update_enrollment_records",
+                        PluginSignals.SIGNAL_PATH: (
+                            "openedx_events.learning.signals."
+                            "COURSE_UNENROLLMENT_COMPLETED"
+                        ),
+                    },
                 ],
             },
         },

--- a/mogc_partnerships/compat.py
+++ b/mogc_partnerships/compat.py
@@ -35,7 +35,7 @@ def update_student_enrollment(course_key, student_email, action):
                 course_key, student_email, auto_enroll=True
             )
         elif action == UNENROLL_ACTION:
-            previous_state, after_state, enrollment_obj = enrollment.unenroll_email(
+            previous_state, after_state = enrollment.unenroll_email(
                 course_key, student_email
             )
         else:

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -103,9 +103,11 @@ class CohortOfferingListView(generics.ListAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["enrollments"] = self.request.user.enrollment_records.filter(
-            is_active=True
-        ).values_list("offering_id", flat=True)
+        context[
+            "enrollments"
+        ] = self.request.user.enrollment_records.active().values_list(
+            "offering_id", flat=True
+        )
         return context
 
     def get_queryset(self):

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -114,7 +114,10 @@ class CohortOfferingListView(generics.ListAPIView):
         managed_offerings = CohortOffering.objects.filter(
             cohort__partner_id__in=managed_partners.values_list("id", flat=True)
         )
-        memberships = user.memberships.all()
+        memberships = user.memberships.filter(active=True).all()
+        if not (managed_offerings or memberships):
+            raise PermissionDenied("User has no active cohort memberships")
+
         member_offerings = CohortOffering.objects.filter(
             cohort__in=memberships.values_list("cohort_id", flat=True)
         )

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -103,7 +103,7 @@ class CohortOfferingListView(generics.ListAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["enrollments"] = self.request.user.enrollment_records.values_list(
+        context["enrollments"] = self.request.user.enrollment_records.filter(is_active=True).values_list(
             "offering_id", flat=True
         )
         return context

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -276,7 +276,7 @@ class TestCohortOfferingListView:
         manager = factories.PartnerManagementMembershipFactory()
         factories.CohortOfferingFactory(cohort__partner=manager.partner)
         offering_list_view = views.CohortOfferingListView.as_view()
-        request = request = api_rf.get("/offerings/")
+        request = api_rf.get("/offerings/")
         force_authenticate(request, manager.user)
 
         response = offering_list_view(request)
@@ -290,13 +290,12 @@ class TestCohortOfferingListView:
         manager = factories.PartnerManagementMembershipFactory()
         factories.CohortOfferingFactory()
         offering_list_view = views.CohortOfferingListView.as_view()
-        request = request = api_rf.get("/offerings/")
+        request = api_rf.get("/offerings/")
         force_authenticate(request, manager.user)
 
         response = offering_list_view(request)
 
-        assert response.status_code == 200
-        assert len(response.data) == 0
+        assert response.status_code == 403
 
     def test_membership_offerings_listed(self, api_rf):
         """Members should see offerings for their cohorts."""
@@ -304,7 +303,7 @@ class TestCohortOfferingListView:
         member = factories.CohortMembershipFactory()
         factories.CohortOfferingFactory(cohort=member.cohort)
         offering_list_view = views.CohortOfferingListView.as_view()
-        request = request = api_rf.get("/offerings/")
+        request = api_rf.get("/offerings/")
         force_authenticate(request, member.user)
 
         response = offering_list_view(request)
@@ -312,13 +311,26 @@ class TestCohortOfferingListView:
         assert response.status_code == 200
         assert len(response.data) == 1
 
+    def test_deactivated_membership_offerings_not_listed(self, api_rf):
+        """Members shouldn't see offerings if they are deactivated."""
+
+        member = factories.CohortMembershipFactory(active=False)
+        factories.CohortOfferingFactory(cohort=member.cohort)
+        offering_list_view = views.CohortOfferingListView.as_view()
+        request = api_rf.get("/offerings/")
+        force_authenticate(request, member.user)
+
+        response = offering_list_view(request)
+
+        assert response.status_code == 403
+
     def test_other_offerings_not_listed(self, api_rf):
         """Members shouldn't see offerings from cohorts if they aren't a member."""
 
         member = factories.CohortMembershipFactory()
         factories.CohortOfferingFactory()
         offering_list_view = views.CohortOfferingListView.as_view()
-        request = request = api_rf.get("/offerings/")
+        request = api_rf.get("/offerings/")
         force_authenticate(request, member.user)
 
         response = offering_list_view(request)


### PR DESCRIPTION
Corrects issues with the deactivation flow:
- Incorrect return values used in edX unenroll action
- Filter serialized enrollments on user offerings by active
- Move enrollment object update to _after_ the edX compat call (Django was returning early from this method unexpectedly?)
- Check for deactivation in update request before going through unenroll flow (may not have had any unintended consequences outside of my own local testing while manually manipulating DB data)
- Return 403 on `CohortOfferingListView` if user is not a manager or they have no active memberships
- Add receiver for unenrollment in `apps.py` for when a learner unenrolls from the learner portal