### PR TITLE
Pass login URL into Cohort Invite email template context

### DIFF
--- a/mogc_partnerships/messages.py
+++ b/mogc_partnerships/messages.py
@@ -41,7 +41,16 @@ def send_cohort_membership_invite(member):
     Triggers an invitation email to new users in a cohort.
     """
     cohort = member.cohort
+    partner = cohort.partner
     user = member.user
+
+    base_url = "https://apps.learn.online.umich.edu/partners"
+    next_url = "{}/{}/details".format(base_url, partner.slug)
+    auth_path = "register" if not user else "login"
+    login_url = "https://apps.learn.online.umich.edu/authn/{}/?next={}".format(
+        auth_path, next_url
+    )
+
     context = {
         "user": {"first_name": user.first_name if user else ""},
         "cohort": {
@@ -49,11 +58,11 @@ def send_cohort_membership_invite(member):
             "uuid": cohort.uuid,
         },
         "partner": {
-            "name": cohort.partner.name,
-            "slug": cohort.partner.slug,
-            "org": cohort.partner.org,
+            "name": partner.name,
+            "slug": partner.slug,
+            "org": partner.org,
         },
-        "base_url": "",
+        "login_url": login_url,
     }
 
     send_message(cohort_membership_invite, member, context)


### PR DESCRIPTION
Updates Cohort Invite email context to include the appropriate login URL depending on if the member has a user account or not. If so, they will land on the Sign In tab, and if not, they will land on the Register tab. They will then be routed to the partner details page where they will see the available offerings.