### PR TITLE
Convert Cohort Member import to background task

### DIFF
--- a/mogc_partnerships/exceptions.py
+++ b/mogc_partnerships/exceptions.py
@@ -1,0 +1,2 @@
+class CohortMembershipImportError(Exception):
+    pass

--- a/mogc_partnerships/tasks.py
+++ b/mogc_partnerships/tasks.py
@@ -1,11 +1,15 @@
 import logging
 
+from django.contrib.auth import get_user_model
+
 from celery import shared_task
 from opaque_keys.edx.keys import CourseKey
 
+from . import tasks
 from .compat import get_course_overview_or_none
+from .exceptions import CohortMembershipImportError
 from .messages import send_cohort_membership_invite
-from .models import Partner, PartnerOffering
+from .models import CohortMembership, Partner, PartnerOffering
 
 logger = logging.getLogger(__name__)
 
@@ -38,3 +42,39 @@ def trigger_send_cohort_membership_invite(cohort_membership):
 def trigger_send_cohort_membership_invites(cohort_memberships):
     for member in cohort_memberships:
         send_cohort_membership_invite(member)
+
+
+def batch_create_memberships(cohort, member_emails):
+    try:
+        User = get_user_model()
+        membership_accounts = User.objects.filter(
+            email__in=[email for email in member_emails]
+        )
+        account_email_map = {user.email: user for user in membership_accounts}
+
+        cohort_memberships = [
+            CohortMembership(
+                user=account_email_map.get(member_email),
+                cohort=cohort,
+                email=member_email,
+            )
+            for member_email in member_emails
+        ]
+
+        objects = CohortMembership.objects.bulk_create(
+            cohort_memberships, ignore_conflicts=True
+        )
+        # bulk_create doesn't return autoincremented IDs with MySQL DBs
+        # so we have to query results separately
+        cohort_memberships = CohortMembership.objects.filter(
+            email__in=[cm.email for cm in objects], cohort=cohort
+        )
+
+        tasks.trigger_send_cohort_membership_invites(cohort_memberships)
+    except Exception as e:
+        raise CohortMembershipImportError(e)
+
+
+@shared_task
+def trigger_batch_create_memberships(cohort, member_emails):
+    batch_create_memberships(cohort, member_emails)

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib.auth import get_user_model
 from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404, redirect
@@ -17,6 +19,7 @@ from rest_framework.views import APIView
 from mogc_partnerships import serializers
 
 from . import compat, tasks
+from .exceptions import CohortMembershipImportError
 from .lib import get_cohort
 from .models import (
     CohortMembership,
@@ -29,6 +32,8 @@ from .models import (
 )
 from .pagination import LargeResultsSetPagination
 from .permissions import ManagerCreatePermission, ManagerEditPermission
+
+logger = logging.getLogger(__name__)
 
 
 class PartnerListView(APIView):
@@ -170,33 +175,7 @@ class CohortMembershipCreateView(generics.CreateAPIView):
     def create_collection(self, validated_data, cohort):
         member_emails = [od["email"] for od in validated_data]
 
-        User = get_user_model()
-        membership_accounts = User.objects.filter(
-            email__in=[email for email in member_emails]
-        )
-        account_email_map = {user.email: user for user in membership_accounts}
-
-        cohort_memberships = [
-            CohortMembership(
-                user=account_email_map.get(member_email),
-                cohort=cohort,
-                email=member_email,
-            )
-            for member_email in member_emails
-        ]
-
-        objects = CohortMembership.objects.bulk_create(
-            cohort_memberships, ignore_conflicts=True
-        )
-        # bulk_create doesn't return autoincremented IDs with MySQL DBs
-        # so we have to query results separately
-        cohort_memberships = CohortMembership.objects.filter(
-            email__in=[cm.email for cm in objects], cohort=cohort
-        )
-
-        tasks.trigger_send_cohort_membership_invites(cohort_memberships)
-
-        return cohort_memberships
+        tasks.trigger_batch_create_memberships(cohort, member_emails)
 
     def create_instance(self, validated_data, cohort):
         validated_data["cohort"] = cohort
@@ -221,11 +200,12 @@ class CohortMembershipCreateView(generics.CreateAPIView):
 
         validated_data = serializer.validated_data
         if isinstance(validated_data, list):
-            memberships = self.create_collection(validated_data, cohort)
-            return Response(
-                self.serializer_class(memberships, many=True).data,
-                status=status.HTTP_201_CREATED,
-            )
+            try:
+                self.create_collection(validated_data, cohort)
+                return Response(status=status.HTTP_201_CREATED)
+            except CohortMembershipImportError as e:
+                logger.error(e)
+                return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         membership = self.create_instance(validated_data, cohort)
         return Response(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -486,7 +486,9 @@ class TestCohortMembershipCreateView:
 
     def test_bulk_create(self, api_rf, mocker):
         """Managers can upload a list of emails to bulk create memberships"""
-        import_task_mock = mocker.patch("mogc_partnerships.tasks.batch_create_memberships")
+        import_task_mock = mocker.patch(
+            "mogc_partnerships.tasks.batch_create_memberships"
+        )
 
         manager = factories.PartnerManagementMembershipFactory()
         cohort = factories.PartnerCohortFactory(partner=manager.partner)
@@ -507,7 +509,9 @@ class TestCohortMembershipCreateView:
 
     def test_bulk_create_with_existing_user(self, api_rf, mocker):
         """Managers can upload a list of emails to bulk create memberships for existing user emails"""
-        import_task_mock = mocker.patch("mogc_partnerships.tasks.batch_create_memberships")
+        import_task_mock = mocker.patch(
+            "mogc_partnerships.tasks.batch_create_memberships"
+        )
 
         manager = factories.PartnerManagementMembershipFactory()
         factories.UserFactory(email="foo@bar.com")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -486,7 +486,7 @@ class TestCohortMembershipCreateView:
 
     def test_bulk_create(self, api_rf, mocker):
         """Managers can upload a list of emails to bulk create memberships"""
-        edx_ace_mock = mocker.patch("edx_ace.ace.send")
+        import_task_mock = mocker.patch("mogc_partnerships.tasks.batch_create_memberships")
 
         manager = factories.PartnerManagementMembershipFactory()
         cohort = factories.PartnerCohortFactory(partner=manager.partner)
@@ -503,12 +503,11 @@ class TestCohortMembershipCreateView:
         response = member_create_view(request, cohort_uuid=cohort.uuid)
 
         assert response.status_code == 201
-        assert len(response.data) == 10
-        assert edx_ace_mock.call_count == 10
+        assert import_task_mock.call_count == 1
 
     def test_bulk_create_with_existing_user(self, api_rf, mocker):
-        """Managers can upload a list of emails to bulk create memberships"""
-        edx_ace_mock = mocker.patch("edx_ace.ace.send")
+        """Managers can upload a list of emails to bulk create memberships for existing user emails"""
+        import_task_mock = mocker.patch("mogc_partnerships.tasks.batch_create_memberships")
 
         manager = factories.PartnerManagementMembershipFactory()
         factories.UserFactory(email="foo@bar.com")
@@ -526,8 +525,7 @@ class TestCohortMembershipCreateView:
         response = member_create_view(request, cohort_uuid=cohort.uuid)
 
         assert response.status_code == 201
-        assert len(response.data) == 1
-        assert edx_ace_mock.call_count == 1
+        assert import_task_mock.call_count == 1
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -508,7 +508,10 @@ class TestCohortMembershipCreateView:
         assert import_task_mock.call_count == 1
 
     def test_bulk_create_with_existing_user(self, api_rf, mocker):
-        """Managers can upload a list of emails to bulk create memberships for existing user emails"""
+        """
+        Managers can upload a list of emails to bulk create memberships
+        for existing user emails
+        """
         import_task_mock = mocker.patch(
             "mogc_partnerships.tasks.batch_create_memberships"
         )


### PR DESCRIPTION
### Fixes https://trello.com/c/wlqLlotm/619-partners-cohort-details-member-import-should-be-a-background-task

Converts cohort membership upload to a background task to ensure the import doesn't fail on lists that may timeout before completion.

Frontend PR [HERE](https://github.com/academic-innovation/frontend-app-mogc-partners/pull/84).