### PR TITLE
Disable cohort invite email

### DIFF
--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -200,9 +200,10 @@ class CohortMembershipCreateView(generics.CreateAPIView):
         )
         cohort_membership_ids = cohort_memberships.values_list("id", flat=True)
 
-        tasks.trigger_send_cohort_membership_invites.delay(
-            cohort_membership_ids=list(cohort_membership_ids)
-        )
+        # NOTE: Temporarily disabled
+        # tasks.trigger_send_cohort_membership_invites.delay(
+        #     cohort_membership_ids=list(cohort_membership_ids)
+        # )
 
         return cohort_memberships
 
@@ -217,9 +218,10 @@ class CohortMembershipCreateView(generics.CreateAPIView):
 
         cohort_membership = CohortMembership.objects.create(**validated_data)
 
-        tasks.trigger_send_cohort_membership_invite.delay(
-            cohort_membership_id=cohort_membership.id
-        )
+        # NOTE: Temporarily disabled
+        # tasks.trigger_send_cohort_membership_invite.delay(
+        #     cohort_membership_id=cohort_membership.id
+        # )
 
         return cohort_membership
 

--- a/mogc_partnerships/views.py
+++ b/mogc_partnerships/views.py
@@ -16,7 +16,7 @@ from rest_framework.views import APIView
 
 from mogc_partnerships import serializers
 
-from . import compat, tasks
+from . import compat
 from .lib import get_cohort
 from .models import (
     CohortMembership,
@@ -198,12 +198,6 @@ class CohortMembershipCreateView(generics.CreateAPIView):
         cohort_memberships = CohortMembership.objects.filter(
             email__in=[cm.email for cm in objects], cohort=cohort
         )
-        cohort_membership_ids = cohort_memberships.values_list("id", flat=True)
-
-        # NOTE: Temporarily disabled
-        # tasks.trigger_send_cohort_membership_invites.delay(
-        #     cohort_membership_ids=list(cohort_membership_ids)
-        # )
 
         return cohort_memberships
 
@@ -217,11 +211,6 @@ class CohortMembershipCreateView(generics.CreateAPIView):
             validated_data["user"] = None
 
         cohort_membership = CohortMembership.objects.create(**validated_data)
-
-        # NOTE: Temporarily disabled
-        # tasks.trigger_send_cohort_membership_invite.delay(
-        #     cohort_membership_id=cohort_membership.id
-        # )
 
         return cohort_membership
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -482,7 +482,9 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert cohort.memberships.first().email == "a@b.com"
-        assert mock_message_task.call_count == 1
+        # TODO: Revert when email reenabled
+        # assert mock_message_task.call_count == 1
+        assert mock_message_task.call_count == 0
 
     def test_only_own_cohort(self, api_rf):
         """Managers can't create memberships for cohorts they don't manage."""
@@ -520,7 +522,9 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert len(response.data) == 10
-        assert mock_message_task.call_count == 1
+        # TODO: Revert when email reenabled
+        # assert mock_message_task.call_count == 1
+        assert mock_message_task.call_count == 0
 
     def test_bulk_create_with_existing_user(self, api_rf, mocker):
         """
@@ -548,7 +552,9 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert len(response.data) == 1
-        assert mock_message_task.call_count == 1
+        # TODO: Revert when email reenabled
+        # assert mock_message_task.call_count == 1
+        assert mock_message_task.call_count == 0
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -466,12 +466,8 @@ class TestCohortMembershipListView:
 class TestCohortMembershipCreateView:
     """Tests for CohortMembershipCreateView."""
 
-    def test_manager_can_create_membership(self, api_rf, mocker):
+    def test_manager_can_create_membership(self, api_rf):
         """Managers can create membership for cohorts they manage."""
-        mock_message_task = mocker.patch(
-            "mogc_partnerships.tasks.trigger_send_cohort_membership_invite.delay"
-        )
-
         manager = factories.PartnerManagementMembershipFactory()
         cohort = factories.PartnerCohortFactory(partner=manager.partner)
         member_create_view = views.CohortMembershipCreateView.as_view()
@@ -482,9 +478,6 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert cohort.memberships.first().email == "a@b.com"
-        # TODO: Revert when email reenabled
-        # assert mock_message_task.call_count == 1
-        assert mock_message_task.call_count == 0
 
     def test_only_own_cohort(self, api_rf):
         """Managers can't create memberships for cohorts they don't manage."""
@@ -500,12 +493,8 @@ class TestCohortMembershipCreateView:
         assert response.status_code == 403
         assert not cohort.memberships.exists()
 
-    def test_bulk_create(self, api_rf, mocker):
+    def test_bulk_create(self, api_rf):
         """Managers can upload a list of emails to bulk create memberships"""
-        mock_message_task = mocker.patch(
-            "mogc_partnerships.tasks.trigger_send_cohort_membership_invites.delay"
-        )
-
         manager = factories.PartnerManagementMembershipFactory()
         cohort = factories.PartnerCohortFactory(partner=manager.partner)
         member_create_view = views.CohortMembershipCreateView.as_view()
@@ -522,19 +511,12 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert len(response.data) == 10
-        # TODO: Revert when email reenabled
-        # assert mock_message_task.call_count == 1
-        assert mock_message_task.call_count == 0
 
-    def test_bulk_create_with_existing_user(self, api_rf, mocker):
+    def test_bulk_create_with_existing_user(self, api_rf):
         """
         Managers can upload a list of emails to bulk create memberships
         for existing user emails
         """
-        mock_message_task = mocker.patch(
-            "mogc_partnerships.tasks.trigger_send_cohort_membership_invites.delay"
-        )
-
         manager = factories.PartnerManagementMembershipFactory()
         factories.UserFactory(email="foo@bar.com")
         cohort = factories.PartnerCohortFactory(partner=manager.partner)
@@ -552,9 +534,6 @@ class TestCohortMembershipCreateView:
 
         assert response.status_code == 201
         assert len(response.data) == 1
-        # TODO: Revert when email reenabled
-        # assert mock_message_task.call_count == 1
-        assert mock_message_task.call_count == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Preemptively preparing this PR to disable the Cohort Invite email due to a potential change in plans regarding AAUM 2024 pilot.