### PR TITLE
Skip email activation for new users

### DIFF
--- a/mogc_partnerships/receivers.py
+++ b/mogc_partnerships/receivers.py
@@ -11,6 +11,7 @@ def link_user_to_invite(user: UserData, **kwargs):
     email = user.pii.email
     auth_user = AuthUser.objects.get(email=email)
     auth_user.is_active = True
+    auth_user.save()
     CohortMembership.objects.filter(email=email, user=None).update(user=auth_user)
 
 

--- a/mogc_partnerships/receivers.py
+++ b/mogc_partnerships/receivers.py
@@ -9,7 +9,7 @@ from .models import CohortMembership, EnrollmentRecord, PartnerOffering
 def link_user_to_invite(user: UserData, **kwargs):
     AuthUser = get_user_model()
     email = user.pii.email
-    auth_user = AuthUser.objects.get(email=email)
+    auth_user = AuthUser.objects.get(email=email, is_active=True)
     CohortMembership.objects.filter(email=email, user=None).update(user=auth_user)
 
 

--- a/mogc_partnerships/receivers.py
+++ b/mogc_partnerships/receivers.py
@@ -9,7 +9,8 @@ from .models import CohortMembership, EnrollmentRecord, PartnerOffering
 def link_user_to_invite(user: UserData, **kwargs):
     AuthUser = get_user_model()
     email = user.pii.email
-    auth_user = AuthUser.objects.get(email=email, is_active=True)
+    auth_user = AuthUser.objects.get(email=email)
+    auth_user.is_active = True
     CohortMembership.objects.filter(email=email, user=None).update(user=auth_user)
 
 


### PR DESCRIPTION
Band-aid fix for: https://trello.com/c/ms1r75TM/623-molp-register-sign-in-user-dashboard-is-blank-after-creating-new-account-and-before-activating-via-the-mo-email

Currently, new members/users must activate their new account via an email. This skips the email verification.