### PR TITLE
Delay Email-sending Celery tasks until transaction commits

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -462,7 +462,7 @@ class TestCohortMembershipListView:
         assert response.status_code == 200
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestCohortMembershipCreateView:
     """Tests for CohortMembershipCreateView."""
 


### PR DESCRIPTION
There is a race condition when a database object is created, and then is immediately attempted for fetch in a triggered Celery task. This uses Django's prescribed method of delaying execution of actions until after the database transaction completes.
- Tests need to use the `pytest.mark.django_db(transaction=True)` decorator to ensure that `on_commit` gets executed for in the embedded view.