### PR TITLE
Support Django 4.2

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -64,4 +64,4 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --user --upgrade nox
-      - run: nox -s "test(django=${{ matrix.django }})"
+      - run: nox -s "test(python='${{ matrix.python }}', django='${{ matrix.django }}')"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,11 +41,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        django: ["3.2.0", "4.2.0", "5.0.0", "5.1.0"]
+        exclude:
+          - django: "5.0.0"
+            python: "3.8"
+          - django: "5.1.0"
+            python: "3.8"
+          - django: "5.0.0"
+            python: "3.9"
+          - django: "5.1.0"
+            python: "3.9"
+          - django: "3.2.0"
+            python: "3.11"
+          - django: "3.2.0"
+            python: "3.12"
+          - django: "3.2.0"
+            python: "3.13"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --user --upgrade nox
-      - run: nox -s test
+      - run: nox -s "test(django=${{ matrix.django }})"

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,14 +25,32 @@ def format(session):
 @nox.session
 def migrations(session):
     """Checks that all expected migrations are present."""
-    session.install("django~=3.2.0")
+    session.install("django~=4.2.0")
     session.install("-r", "requirements.txt")
     session.run("python", "manage.py", "makemigrations", "--check")
 
 
 @nox.session
-def test(session):
+@nox.parametrize(
+    "python,django",
+    [
+        (python, django)
+        for python in ("3.8", "3.9", "3.10", "3.11", "3.12", "3.13")
+        for django in ("3.2.0", "4.2.0", "5.0.0", "5.1.0")
+        if (python, django)
+        not in [
+            ("3.8", "5.0.0"),
+            ("3.8", "5.1.0"),
+            ("3.9", "5.0.0"),
+            ("3.9", "5.1.0"),
+            ("3.11", "3.2.0"),
+            ("3.12", "3.2.0"),
+            ("3.13", "3.2.0"),
+        ]
+    ],
+)
+def test(session, django):
     """Runs tests with pytest."""
-    session.install("django~=3.2.0")
+    session.install(f"django~={django}")
     session.install("-r", "requirements.txt")
     session.run("pytest")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black
 celery
-django<4.0
-djangorestframework==3.13.1
+django<5.0
+djangorestframework==3.15.2
 edx-ace==1.9.1
 edx-django-utils==5.14.2
 edx-drf-extensions

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import find_packages, setup
 
 setup(
     name="mogc-partnerships",
-    version="0.4.6",
+    version="0.4.7b1",
     packages=find_packages(),
     install_requires=[
-        "django>=3.2,<4.0",
+        "django>=3.2,<5.0",
         "edx-django-utils",
         "openedx-events>=0.8.1",
         "openedx-filters>=0.7.0",


### PR DESCRIPTION
Necessary to support Quince

- No library code changes
- Updated Django REST Framework to a 4.2 compatible version
- Parameterized the noxfile to cover Python versions 3.8 through 3.13, and Django versions 3.2, and 4.2 through 5.1
- Updated Github Actions to also cover versions tested by nox parameters